### PR TITLE
Add converter and object options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Full documentation can be found at: https://pkg.go.dev/github.com/adrg/go-wkhtml
 
 Examples:  
 * [Basic usage](examples/basic-usage/main.go)
+* [Convert HTML document based on JSON input](examples/json-input/main.go)
 * [Basic web page to PDF conversion server](examples/http-server)
 * [Configurable web page to PDF conversion server](examples/http-server-advanced)
 
@@ -47,7 +48,10 @@ import (
 )
 
 func main() {
-	pdf.Init()
+	// Initialize library.
+	if err := pdf.Init(); err != nil {
+		log.Fatal(err)
+	}
 	defer pdf.Destroy()
 
 	// Create object from file.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ go-wkhtmltopdf
 [![pkg.go.dev documentation](https://pkg.go.dev/badge/github.com/adrg/go-wkhtmltopdf)](https://pkg.go.dev/github.com/adrg/go-wkhtmltopdf)
 [![MIT license](https://img.shields.io/badge/license-MIT-red.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Go report card](https://goreportcard.com/badge/github.com/adrg/go-wkhtmltopdf)](https://goreportcard.com/report/github.com/adrg/go-wkhtmltopdf)
+[![GitHub issues](https://img.shields.io/github/issues/adrg/go-wkhtmltopdf)](https://github.com/adrg/go-wkhtmltopdf/issues)
+[![Buy me a coffee](https://img.shields.io/static/v1.svg?label=%20&message=Buy%20me%20a%20coffee&color=FF813F&logo=buy%20me%20a%20coffee&logoColor=white)](https://www.buymeacoffee.com/adrg)
+[![GitHub stars](https://img.shields.io/github/stars/adrg/go-wkhtmltopdf?style=social)](https://github.com/adrg/go-wkhtmltopdf/stargazers)
 
 Implements [wkhtmltopdf](https://wkhtmltopdf.org) Go bindings. It can be used to convert HTML documents to PDF files.
 The package does not use the `wkhtmltopdf` binary. Instead, it uses the `wkhtmltox` library directly.
@@ -131,6 +134,13 @@ See [CONTRIBUTING.MD](https://github.com/adrg/go-wkhtmltopdf/blob/master/CONTRIB
 
 For more information see the [wkhtmltopdf documentation](https://wkhtmltopdf.org/usage/wkhtmltopdf.txt)
 and the [wkhtmltox documentation](https://wkhtmltopdf.org/libwkhtmltox).
+
+## Buy me a coffee
+
+If you found this project useful and want to support it, consider buying me a coffee.  
+<a href="https://www.buymeacoffee.com/adrg">
+    <img src="https://cdn.buymeacoffee.com/buttons/v2/arial-orange.png" alt="Buy Me A Coffee" height="42px">
+</a>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 go-wkhtmltopdf
 ==============
+[![Build Status](https://github.com/adrg/go-wkhtmltopdf/workflows/CI/badge.svg)](https://github.com/adrg/go-wkhtmltopdf/actions?query=workflow%3ACI)
 [![pkg.go.dev documentation](https://pkg.go.dev/badge/github.com/adrg/go-wkhtmltopdf)](https://pkg.go.dev/github.com/adrg/go-wkhtmltopdf)
 [![MIT license](https://img.shields.io/badge/license-MIT-red.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Go report card](https://goreportcard.com/badge/github.com/adrg/go-wkhtmltopdf)](https://goreportcard.com/report/github.com/adrg/go-wkhtmltopdf)
@@ -11,7 +12,8 @@ Full documentation can be found at: https://pkg.go.dev/github.com/adrg/go-wkhtml
 
 Examples:  
 * [Basic usage](examples/basic-usage/main.go)
-* [Web page to PDF conversion server](examples/http-server)
+* [Basic web page to PDF conversion server](examples/http-server)
+* [Configurable web page to PDF conversion server](examples/http-server-advanced)
 
 ## Prerequisites
 

--- a/converter.go
+++ b/converter.go
@@ -157,19 +157,19 @@ type ConverterOpts struct {
 //
 //   Defaults options:
 //
-//   PaperSize:       A4,
-//   Orientation:     Portrait,
-//   Colorspace:      Color,
-//   DPI:             96,
-//   Copies:          1,
-//   Collate:         true,
-//   GenerateOutline: true,
-//   OutlineDepth:    4,
-//   UseCompression:  true,
-//   MarginLeft:      "10mm",
-//   MarginRight:     "10mm",
-//   ImageDPI:        600,
-//   ImageQuality:    100,
+//   PaperSize:       A4
+//   Orientation:     Portrait
+//   Colorspace:      Color
+//   DPI:             96
+//   Copies:          1
+//   Collate:         true
+//   GenerateOutline: true
+//   OutlineDepth:    4
+//   UseCompression:  true
+//   MarginLeft:      "10mm"
+//   MarginRight:     "10mm"
+//   ImageDPI:        600
+//   ImageQuality:    100
 func NewConverterOpts() *ConverterOpts {
 	return &ConverterOpts{
 		PaperSize:       A4,
@@ -197,14 +197,14 @@ type Converter struct {
 	objects   []*Object
 }
 
-// NewConverter returns a new converter instance, configured using the default
-// options. See NewConverterOpts for the default options.
+// NewConverter returns a new converter instance, configured using sensible
+// defaults. See NewConverterOpts for the default options.
 func NewConverter() (*Converter, error) {
 	return NewConverterWithOpts(nil)
 }
 
 // NewConverterWithOpts returns a new converter instance, configured using the
-// specified options. If no options are provided, the default options are used.
+// specified options. If no options are provided, sensible defaults are used.
 // See NewConverterOpts for the default options.
 func NewConverterWithOpts(opts *ConverterOpts) (*Converter, error) {
 	if opts == nil {

--- a/converter.go
+++ b/converter.go
@@ -275,12 +275,6 @@ func (c *Converter) Run(w io.Writer) error {
 
 // Destroy releases all resources used by the converter.
 func (c *Converter) Destroy() {
-	// Destroy converter objects.
-	for _, o := range c.objects {
-		o.Destroy()
-	}
-	c.objects = nil
-
 	// Destroy settings.
 	if c.settings != nil {
 		C.wkhtmltopdf_destroy_global_settings(c.settings)
@@ -292,6 +286,12 @@ func (c *Converter) Destroy() {
 		C.wkhtmltopdf_destroy_converter(c.converter)
 		c.converter = nil
 	}
+
+	// Destroy converter objects.
+	for _, o := range c.objects {
+		o.Destroy()
+	}
+	c.objects = nil
 }
 
 func (c *Converter) setOption(name, value string) error {

--- a/converter.go
+++ b/converter.go
@@ -231,19 +231,23 @@ func (c *Converter) Run(w io.Writer) error {
 
 // Destroy releases all resources used by the converter.
 func (c *Converter) Destroy() {
-	if c.converter == nil {
-		return
-	}
-
 	// Destroy converter objects.
 	for _, o := range c.objects {
 		o.Destroy()
 	}
 	c.objects = nil
 
+	// Destroy settings.
+	if c.settings != nil {
+		C.wkhtmltopdf_destroy_global_settings(c.settings)
+		c.settings = nil
+	}
+
 	// Destroy converter.
-	C.wkhtmltopdf_destroy_converter(c.converter)
-	c.converter = nil
+	if c.converter != nil {
+		C.wkhtmltopdf_destroy_converter(c.converter)
+		c.converter = nil
+	}
 }
 
 func (c *Converter) setOption(name, value string) error {

--- a/converter.go
+++ b/converter.go
@@ -7,7 +7,6 @@ package pdf
 #include <wkhtmltox/pdf.h>
 */
 import "C"
-
 import (
 	"bytes"
 	"errors"
@@ -76,81 +75,81 @@ const (
 type ConverterOpts struct {
 	// The paper size of the output document.
 	// E.g.: A4.
-	PaperSize PaperSize
+	PaperSize PaperSize `json:"paperSize" yaml:"paperSize"`
 
 	// The width of the output document.
 	// E.g.: "4cm".
-	Width string
+	Width string `json:"width" yaml:"width"`
 
 	// The height of the output document.
 	// E.g. "12in".
-	Height string
+	Height string `json:"height" yaml:"height"`
 
 	// The orientation of the output document.
 	// E.g.: Potrait.
-	Orientation Orientation
+	Orientation Orientation `json:"orientation" yaml:"orientation"`
 
 	// The color mode of the output document.
 	// E.g.: Color.
-	Colorspace Colorspace
+	Colorspace Colorspace `json:"colorspace" yaml:"colorspace"`
 
 	// DPI of the output document.
 	// E.g.: 96.
-	DPI uint64
+	DPI uint64 `json:"dpi" yaml:"dpi"`
 
 	// A number added to all page numbers when rendering headers, footers and
 	// tables of contents.
-	PageOffset int64
+	PageOffset int64 `json:"pageOffset" yaml:"pageOffset"`
 
 	// Copies of the converted documents to be included in the output document.
 	// E.g.: 1.
-	Copies uint64
+	Copies uint64 `json:"copies" yaml:"copies"`
 
 	// Specifies whether copies should be collated.
-	Collate bool
+	Collate bool `json:"collate" yaml:"collate"`
 
 	// The title of the output document.
-	Title string
+	Title string `json:"title" yaml:"title"`
 
 	// Specifies whether outlines should be generated for the output document.
-	GenerateOutline bool
+	GenerateOutline bool `json:"generateOutline" yaml:"generateOutline"`
 
 	// The maximum number of nesting levels in outlines.
 	// E.g.: 4.
-	OutlineDepth uint64
+	OutlineDepth uint64 `json:"outlineDepth" yaml:"outlineDepth"`
 
 	// A location to write an XML representation of the generated outlines.
-	OutlineDumpPath string
+	OutlineDumpPath string `json:"outlineDumpPath" yaml:"outlineDumpPath"`
 
 	// Specifies whether the conversion process should use lossless compression.
-	UseCompression bool
+	UseCompression bool `json:"useCompression" yaml:"useCompression"`
 
 	// Size of the top margin. (e.g. "2cm")
 	// E.g.: "1cm".
-	MarginTop string
+	MarginTop string `json:"marginTop" yaml:"marginTop"`
 
 	// Size of the bottom margin. (e.g. "2cm")
 	// E.g.: "1cm".
-	MarginBottom string
+	MarginBottom string `json:"marginBottom" yaml:"marginBottom"`
 
 	// Size of the left margin. (e.g. "2cm")
 	// Default: "10mm".
-	MarginLeft string
+	MarginLeft string `json:"marginLeft" yaml:"marginLeft"`
 
 	// Size of the right margin. (e.g. "2cm")
 	// E.g.: "10mm".
-	MarginRight string
+	MarginRight string `json:"marginRight" yaml:"marginRight"`
 
 	// The maximum number of DPI for the images in the output document.
 	// E.g.: 600.
-	ImageDPI uint64
+	ImageDPI uint64 `json:"imageDPI" yaml:"imageDPI"`
 
 	// The compression factor to use for the JPEG images in the output document.
 	// E.g.: 100 (range 0-100).
-	ImageQuality uint64
+	ImageQuality uint64 `json:"imageQuality" yaml:"imageQuality"`
 
 	// Path of the file used to load and store cookies for web objects.
-	CookieJarPath string
+	CookieJarPath string `json:"cookieJarPath" yaml:"cookieJarPath"`
 }
 
 // NewConverterOpts returns a new instance of converter options, configured

--- a/converter.go
+++ b/converter.go
@@ -86,7 +86,7 @@ type ConverterOpts struct {
 	Height string `json:"height" yaml:"height"`
 
 	// The orientation of the output document.
-	// E.g.: Potrait.
+	// E.g.: Portrait.
 	Orientation Orientation `json:"orientation" yaml:"orientation"`
 
 	// The color mode of the output document.
@@ -133,7 +133,7 @@ type ConverterOpts struct {
 	MarginBottom string `json:"marginBottom" yaml:"marginBottom"`
 
 	// Size of the left margin. (e.g. "2cm")
-	// Default: "10mm".
+	// E.g.: "10mm".
 	MarginLeft string `json:"marginLeft" yaml:"marginLeft"`
 
 	// Size of the right margin. (e.g. "2cm")

--- a/examples/basic-usage/main.go
+++ b/examples/basic-usage/main.go
@@ -8,7 +8,10 @@ import (
 )
 
 func main() {
-	pdf.Init()
+	// Initialize library.
+	if err := pdf.Init(); err != nil {
+		log.Fatal(err)
+	}
 	defer pdf.Destroy()
 
 	// Create object from file.

--- a/examples/http-server-advanced/README.md
+++ b/examples/http-server-advanced/README.md
@@ -1,0 +1,51 @@
+## Overview
+
+The example showcases a configurable web page to PDF conversion server.
+
+**The problem**
+
+The biggest challenge is that `wkhtmltopdf` can only run on the `main
+thread`, the problem being that the `HTTP server` runs each request in
+a separate `goroutine`.
+
+For more information, see:  
+• [https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1711](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1711)  
+• [https://forum.dlang.org/thread/qmnmirbwmrvwexaewmtw@forum.dlang.org](https://forum.dlang.org/thread/qmnmirbwmrvwexaewmtw@forum.dlang.org)  
+• [https://forum.qt.io/topic/84485/qapplication-not-created-in-main-thread/9](https://forum.qt.io/topic/84485/qapplication-not-created-in-main-thread/9)
+
+**The solution**
+
+The solution is to run the conversion process on the `main thread`. This can
+be achieved as shown [here](https://github.com/golang/go/wiki/LockOSThread).
+There are also a couple of packages which facilitate this, like
+[faiface/mainthread](https://github.com/faiface/mainthread) or
+[olahol/mainthread](https://github.com/olahol/mainthread). The example does
+not use any external library to access the `main thread`.
+
+## Usage
+
+**Run the conversion server.**
+
+```bash
+go run main.go
+```
+
+**Make a conversion request.**
+
+```bash
+curl -H "Content-Type: application/json" -X POST \
+    -o google.pdf 127.0.0.1:8080 \
+    -d'{
+	"converterOpts": {
+		"title": "google.com",
+		"paperSize": "A4",
+		"orientation": "Portrait"
+	},
+	"objectOpts": {
+		"location": "https://google.com",
+		"footer": {
+			"contentCenter": "[page]"
+		}
+	}
+}'
+```

--- a/examples/http-server-advanced/README.md
+++ b/examples/http-server-advanced/README.md
@@ -49,3 +49,5 @@ curl -H "Content-Type: application/json" -X POST \
 	}
 }'
 ```
+
+See full list of options at [https://pkg.go.dev/github.com/adrg/go-wkhtmltopdf](https://pkg.go.dev/github.com/adrg/go-wkhtmltopdf).

--- a/examples/http-server-advanced/main.go
+++ b/examples/http-server-advanced/main.go
@@ -21,7 +21,7 @@ func init() {
 var run = make(chan func())
 
 func main() {
-	// Initialize go-wkhtmltopdf library.
+	// Initialize library.
 	if err := pdf.Init(); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/http-server-advanced/main.go
+++ b/examples/http-server-advanced/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"runtime"
+
+	pdf "github.com/adrg/go-wkhtmltopdf"
+)
+
+func init() {
+	// Set main function to run on the main thread.
+	runtime.LockOSThread()
+}
+
+var run = make(chan func())
+
+func main() {
+	// Initialize go-wkhtmltopdf library.
+	if err := pdf.Init(); err != nil {
+		log.Fatal(err)
+	}
+	defer pdf.Destroy()
+
+	// Start HTTP server on another Go routine.
+	go startServer()
+
+	// Listen for functions that need to run on the main thread.
+	var quit = make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt)
+	for {
+		select {
+		case f := <-run:
+			f()
+		case <-quit:
+			log.Println("shutting down")
+			return
+		}
+	}
+}
+
+// callFunc calls the provided function on the main thread.
+func callFunc(f func() error) error {
+	err := make(chan error)
+	run <- func() {
+		err <- f()
+	}
+	return <-err
+}
+
+type requestData struct {
+	ConverterOpts *pdf.ConverterOpts `json:"converterOpts"`
+	ObjectOpts    *pdf.ObjectOpts    `json:"objectOpts"`
+}
+
+func startServer() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Check request method and path.
+		if r.Method != http.MethodPost || r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+
+		// Set default options. Any option fields specified in the request
+		// body will overwrite the defaults.
+		data := &requestData{
+			ConverterOpts: pdf.NewConverterOpts(),
+			ObjectOpts:    pdf.NewObjectOpts(),
+		}
+
+		// Decode request body.
+		if err := json.NewDecoder(r.Body).Decode(data); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+
+		// Convert the page at the specified URL to PDF.
+		out := bytes.NewBuffer(nil)
+		if err := callFunc(func() error {
+			// Create object with options.
+			object, err := pdf.NewObjectWithOpts(data.ObjectOpts)
+			if err != nil {
+				return err
+			}
+
+			// Create converter with options.
+			converter, err := pdf.NewConverterWithOpts(data.ConverterOpts)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer converter.Destroy()
+
+			// Add object to the converter.
+			converter.Add(object)
+
+			// Perform the conversion.
+			return converter.Run(out)
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+		// Serve converted file.
+		w.Header().Set("Content-Disposition", "attachment; filename=download.pdf")
+		w.Header().Set("Content-Type", "application/pdf")
+		if _, err := io.Copy(w, out); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/examples/http-server/README.md
+++ b/examples/http-server/README.md
@@ -11,6 +11,7 @@ a separate `goroutine`.
 For more information, see:  
 • [https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1711](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1711)  
 • [https://forum.dlang.org/thread/qmnmirbwmrvwexaewmtw@forum.dlang.org](https://forum.dlang.org/thread/qmnmirbwmrvwexaewmtw@forum.dlang.org)  
+• [https://forum.qt.io/topic/84485/qapplication-not-created-in-main-thread/9](https://forum.qt.io/topic/84485/qapplication-not-created-in-main-thread/9)
 
 **The solution**
 

--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -20,7 +20,7 @@ func init() {
 var run = make(chan func())
 
 func main() {
-	// Initialize go-wkhtmltopdf library.
+	// Initialize library.
 	if err := pdf.Init(); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/json-input/main.go
+++ b/examples/json-input/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"strings"
+
+	pdf "github.com/adrg/go-wkhtmltopdf"
+)
+
+// For the full list of options, see pkg.go.dev/github.com/adrg/go-wkhtmltopdf.
+// NOTE: pdf.ConverterOpts and pdf.ObjectOpts also support YAML unmarshalling.
+var jsonInput = strings.NewReader(`{
+	"converterOpts": {
+		"title": "google.com",
+		"paperSize": "A4",
+		"orientation": "Portrait",
+		"marginLeft": "10mm",
+		"marginRight": "10mm"
+	},
+	"objectOpts": {
+		"location": "https://google.com",
+		"footer": {
+			"contentCenter": "[page]",
+			"fontSize": 14
+		}
+	}
+}`)
+
+type inputData struct {
+	ConverterOpts *pdf.ConverterOpts `json:"converterOpts"`
+	ObjectOpts    *pdf.ObjectOpts    `json:"objectOpts"`
+}
+
+func main() {
+	// Initialize library.
+	if err := pdf.Init(); err != nil {
+		log.Fatal(err)
+	}
+	defer pdf.Destroy()
+
+	// Set default options. Any option fields specified in the JSON
+	// input data will overwrite the defaults.
+	input := &inputData{
+		ConverterOpts: pdf.NewConverterOpts(),
+		ObjectOpts:    pdf.NewObjectOpts(),
+	}
+
+	if err := json.NewDecoder(jsonInput).Decode(input); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create object.
+	object, err := pdf.NewObjectWithOpts(input.ObjectOpts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create converter.
+	converter, err := pdf.NewConverterWithOpts(input.ConverterOpts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer converter.Destroy()
+
+	// Add object to the converter.
+	converter.Add(object)
+
+	// Convert object and save the output PDF document.
+	outFile, err := os.Create("out.pdf")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer outFile.Close()
+
+	if err := converter.Run(outFile); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/object.go
+++ b/object.go
@@ -30,36 +30,36 @@ const (
 type TOC struct {
 	// Specifies whether dotted lines should be used for the line of items
 	// of the TOC.
-	UseDottedLines bool
+	UseDottedLines bool `json:"useDottedLines" yaml:"useDottedLines"`
 
 	// The title used for the table of contents.
 	// E.g.: "Table of Contents".
-	Title string
+	Title string `json:"title" yaml:"title"`
 
 	// Specifies whether the TOC items should contain links to the content.
-	GenerateForwardLinks bool
+	GenerateForwardLinks bool `json:"generateForwardLinks" yaml:"generateForwardLinks"`
 
 	// Specifies whether the content should contain links to the TOC.
-	GenerateBackLinks bool
+	GenerateBackLinks bool `json:"generateBackLinks" yaml:"generateBackLinks"`
 
 	// The indentation used for the TOC nesting levels.
 	// E.g.: "1em".
-	Indentation string
+	Indentation string `json:"indentation" yaml:"indentation"`
 
 	// Scaling factor for each nesting level of the TOC.
 	// E.g.: 1.
-	FontScale float64
+	FontScale float64 `json:"fontScale" yaml:"fontScale"`
 }
 
 // Header contains settings related to the headers and footers of an object.
 type Header struct {
 	// The system font name to use for headers/footers.
 	// E.g.: "Arial".
-	Font string
+	Font string `json:"font" yaml:"font"`
 
 	// The font size to use for headers/footers.
 	// E.g.: 12.
-	FontSize uint64
+	FontSize uint64 `json:"fontSize" yaml:"fontSize"`
 
 	// Content to print on each of the available regions of the header/footer.
 	// Substitution variables that can be used in the content fields:
@@ -77,117 +77,117 @@ type Header struct {
 	//  - [sitepage]   The number of the page in the currently converted site.
 	//  - [sitepages]  The number of pages in the current site being converted.
 	// e.g.: object.Footer.ContentRight = "[page]"
-	ContentLeft   string
-	ContentCenter string
-	ContentRight  string
+	ContentLeft   string `json:"contentLeft" yaml:"contentLeft"`
+	ContentCenter string `json:"contentCenter" yaml:"contentCenter"`
+	ContentRight  string `json:"contentRight" yaml:"contentRight"`
 
 	// Specifies whether a line separator should be printed for headers/footers.
-	DisplaySeparator bool
+	DisplaySeparator bool `json:"displaySeparator" yaml:"displaySeparator"`
 
 	// The amount of space between the header/footer and the content.
 	// E.g.: 0.
-	Spacing float64
+	Spacing float64 `json:"spacing" yaml:"spacing"`
 
 	// Location of a user defined HTML document to be used as the header/footer.
-	CustomLocation string
+	CustomLocation string `json:"customLocation" yaml:"customLocation"`
 }
 
 // ObjectOpts defines a set of options to be used in the conversion process.
 type ObjectOpts struct {
 	// Specifies the location of the HTML document. Can be a file path or a URL.
-	Location string
+	Location string `json:"location" yaml:"location"`
 
 	// Specifies whether external links in the HTML document should be converted
 	// to external PDF links.
-	UseExternalLinks bool
+	UseExternalLinks bool `json:"useExternalLinks" yaml:"useExternalLinks"`
 
 	// Specifies whether internal links in the HTML document should be converted
 	// into PDF references.
-	UseLocalLinks bool
+	UseLocalLinks bool `json:"useLocalLinks" yaml:"useLocalLinks"`
 
 	// Specifies whether HTML forms should be converted into PDF forms.
-	ProduceForms bool
+	ProduceForms bool `json:"produceForms" yaml:"produceForms"`
 
 	// Specifies whether the sections from the HTML document are included in
 	// outlines and TOCs.
-	IncludeInOutline bool
+	IncludeInOutline bool `json:"includeInOutline" yaml:"includeInOutline"`
 
 	// Specifies whether the page count of the HTML document participates in
 	// the counter used for tables of contents, headers and footers.
-	CountPages bool
+	CountPages bool `json:"countPages" yaml:"countPages"`
 
 	// Contains settings for the TOC of the object.
-	TOC TOC
+	TOC TOC `json:"toc" yaml:"toc"`
 
 	// Contains settings for the header of the object.
-	Header Header
+	Header Header `json:"header" yaml:"header"`
 
 	// Contains settings for the footer of the object.
-	Footer Header
+	Footer Header `json:"footer" yaml:"footer"`
 
 	// The username to use when logging in to a website.
-	Username string
+	Username string `json:"username" yaml:"username"`
 
 	// The password to use when logging in to a website.
-	Password string
+	Password string `json:"password" yaml:"password"`
 
 	// The amount of milliseconds to wait after page load, before
 	// executing JS scripts.
 	// E.g.: 300.
-	JavascriptDelay uint64
+	JavascriptDelay uint64 `json:"javascriptDelay" yaml:"javascriptDelay"`
 
 	// Specifies the `window.status` value to wait for, before
 	// rendering the page.
 	// E.g.: "ready".
-	WindowStatus string
+	WindowStatus string `json:"windowStatus" yaml:"windowStatus"`
 
 	// Zoom factor to use for the document content.
 	// E.g.: 1.
-	Zoom float64
+	Zoom float64 `json:"zoom" yaml:"zoom"`
 
 	// Specifies whether local file access is blocked.
-	BlockLocalFileAccess bool
+	BlockLocalFileAccess bool `json:"blockLocalFileAccess" yaml:"blockLocalFileAccess"`
 
 	// Specifies whether slow JS scripts should be stopped.
-	StopSlowScripts bool
+	StopSlowScripts bool `json:"stopSlowScripts" yaml:"stopSlowScripts"`
 
 	// Specifies a course of action when an HTML document fails to load.
 	// E.g.: ActionAbort.
-	ErrorAction ErrorAction
+	ErrorAction ErrorAction `json:"errorAction" yaml:"errorAction"`
 
 	// The name of a proxy to use when loading the HTML document.
-	Proxy string
+	Proxy string `json:"proxy" yaml:"proxy"`
 
 	// Specifies whether the background of the HTML document is preserved.
-	PrintBackground bool
+	PrintBackground bool `json:"printBackground" yaml:"printBackground"`
 
 	// Specifies whether the images in the HTML document are loaded.
-	LoadImages bool
+	LoadImages bool `json:"loadImages" yaml:"loadImages"`
 
 	// Specifies whether Javascript should be executed.
-	EnableJavascript bool
+	EnableJavascript bool `json:"enableJavascript" yaml:"enableJavascript"`
 
 	// Specifies whether to use intelligent shrinkng in order to fit more
 	// content on a page.
-	UseSmartShrinking bool
+	UseSmartShrinking bool `json:"useSmartShrinking" yaml:"useSmartShrinking"`
 
 	// The minimum font size allowed for rendering content.
-	MinFontSize uint64
+	MinFontSize uint64 `json:"minFontSize" yaml:"minFontSize"`
 
 	// The text encoding to use if the HTML document does not specify one.
 	// E.g.: "utf-8".
-	DefaultEncoding string
+	DefaultEncoding string `json:"defaultEncoding" yaml:"defaultEncoding"`
 
 	// Specifies whether the content should be rendered using the print media
 	// type instead of the screen media type.
-	UsePrintMediaType bool
+	UsePrintMediaType bool `json:"usePrintMediaType" yaml:"usePrintMediaType"`
 
 	// The location of a user defined stylesheet to use when converting
 	// the HTML document.
-	UserStylesheetLocation string
+	UserStylesheetLocation string `json:"userStylesheetLocation" yaml:"userStylesheetLocation"`
 
 	// Specifies whether NS plugins should be enabled.
-	EnablePlugins bool
+	EnablePlugins bool `json:"enablePlugins" yaml:"enablePlugins"`
 }
 
 // NewObjectOpts returns a new instance of object options, configured

--- a/object.go
+++ b/object.go
@@ -284,17 +284,18 @@ func newObject(location string, temporary bool) (*Object, error) {
 
 // Destroy releases all resources used by the object.
 func (o *Object) Destroy() {
-	if o.settings == nil {
-		return
-	}
-
-	// Remove temporary files.
+	// Remove temporary file.
 	if o.temporary && o.location != "" {
 		os.Remove(o.location)
+		o.location = ""
+		o.temporary = false
 	}
 
-	C.wkhtmltopdf_destroy_object_settings(o.settings)
-	o.settings = nil
+	// Destroy settings.
+	if o.settings != nil {
+		C.wkhtmltopdf_destroy_object_settings(o.settings)
+		o.settings = nil
+	}
 }
 
 func (o *Object) setOption(name, value string) error {

--- a/object.go
+++ b/object.go
@@ -220,7 +220,7 @@ type ObjectOpts struct {
 //   	FontSize: 12
 //   Footer:
 //   	Font:     "Arial"
-//   	FontSize: 12,
+//   	FontSize: 12
 func NewObjectOpts() *ObjectOpts {
 	return &ObjectOpts{
 		UseExternalLinks:  true,
@@ -333,8 +333,7 @@ func (o *Object) Destroy() {
 	// Remove temporary file.
 	if o.temporary && o.Location != "" {
 		os.Remove(o.Location)
-		o.Location = ""
-		o.temporary = false
+		o.Location, o.temporary = "", false
 	}
 
 	// Destroy settings.


### PR DESCRIPTION
- Destroy global settings on converter destroy
- Separate options from pdf.Converter
- Separate options from pdf.Object
- Add JSON and YAML marshal support for pdf.ConverterOpts
- Add JSON and YAML marshal support for pdf.ObjectOpts
- Add pdf.NewConverterWithOpts and pdf.NewConverterOpts
- Add pdf.NewObjectWithOpts and pdf.NewObjectOpts
- Add HTML document conversion based on JSON input
- Add configurable web page to PDF conversion server example
- Improve README.md